### PR TITLE
Moving to Private NPM on npmjs.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "respro",
+  "name": "@nvite/respro",
   "version": "1.0.2",
   "description": "Resource proxy middleware for Connect/Express.",
   "main": "index.js",
@@ -18,6 +18,9 @@
   "dependencies": {
     "request": "^2.53.0",
     "util-extend": "^1.0.1"
+  },
+   "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "request": "^2.53.0",
     "util-extend": "^1.0.1"
   },
-   "publishConfig": {
+  "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {


### PR DESCRIPTION
Nodejitsu is spinning down services eoy so we are moving everything over to npmjs.com

This requires a major update of packages and renaming of all module loading to use `@nvite/respro`
## Things added / changed
- updating package scope and registry url
